### PR TITLE
Add plainlage.html which was missing from the github repoq

### DIFF
--- a/plainpage.html
+++ b/plainpage.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html id="ie6" lang="en"> <![endif]-->
+<!--[if IE 7]> <html id="ie7" lang="en"> <![endif]-->
+<!--[if IE 8]> <html id="ie8" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UW Libraries</title>
+<link href="css/custom-bootstrap.css" rel="stylesheet" type="text/css" media="screen" />
+<script src="js/jquery-1.8.1.min.js"></script>
+<script src="js/bootstrap.min.js"></script>
+<script src="js/main.js"></script>
+<!--[if lt IE 9]>
+  <script src="js/html5shiv.js" type="text/javascript"></script>
+  <script src="js/respond.min.js" type="text/javascript"></script>
+<![endif]-->
+</head>
+<body class="uwlib-bootstrap">
+<div id="main-content" class="main-content" role="main"><p>Plain page</p></div>
+</body>
+</html>


### PR DESCRIPTION
I discovered plainpage.html was in production but not in the github repo, and the way I was updating the theme on the plone servers was masking that. If it's okay, I'll add it back here.